### PR TITLE
feat: add email body sanitization and HTML sanitizer

### DIFF
--- a/apps/candidate/src/app/(public)/jobs/components/split/split-view.tsx
+++ b/apps/candidate/src/app/(public)/jobs/components/split/split-view.tsx
@@ -33,7 +33,6 @@ export function SplitView({ jobs, selectedId, onSelect }: SplitViewProps) {
             )}
             emptyIcon="fa-hand-pointer"
             emptyTitle="Select a job to view details"
-            initialListWidth={40}
             onMobileClose={() => {
                 const selected = jobs.find((j) => j.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/candidate/src/app/(public)/marketplace/components/split-view.tsx
+++ b/apps/candidate/src/app/(public)/marketplace/components/split-view.tsx
@@ -40,8 +40,6 @@ export default function SplitView({
             )}
             emptyIcon="fa-hand-pointer"
             emptyTitle="Select a recruiter to view details"
-            initialListWidth={38}
-            mobileBreakpoint="lg"
             onMobileClose={() => {
                 if (selectedRecruiter) onSelect(selectedRecruiter);
             }}

--- a/apps/candidate/src/app/globals.css
+++ b/apps/candidate/src/app/globals.css
@@ -2,6 +2,7 @@
 
 @import "tailwindcss";
 @plugin "daisyui";
+@source "../../../../packages/basel-ui/src/**/*.tsx";
 
 @import "./themes/light.css";
 @import "./themes/dark.css";

--- a/apps/candidate/src/app/portal/applications/components/split/split-view.tsx
+++ b/apps/candidate/src/app/portal/applications/components/split/split-view.tsx
@@ -38,7 +38,6 @@ export function SplitView({
             )}
             emptyIcon="fa-hand-pointer"
             emptyTitle="Select an application to view details"
-            initialListWidth={40}
             onMobileClose={() => {
                 const selected = applications.find((a) => a.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/portal/src/app/globals.css
+++ b/apps/portal/src/app/globals.css
@@ -2,6 +2,7 @@
 
 @import "tailwindcss";
 @plugin "daisyui";
+@source "../../../../packages/basel-ui/src/**/*.tsx";
 
 @theme {
     --breakpoint-3xl: 1920px;

--- a/apps/portal/src/app/portal/applications/components/split/split-view.tsx
+++ b/apps/portal/src/app/portal/applications/components/split/split-view.tsx
@@ -39,8 +39,6 @@ export function SplitView({
             emptyIcon="fa-hand-pointer"
             emptyTitle="Select an application"
             emptyDescription="Click an application on the left to view details"
-            initialListWidth={38}
-            mobileBreakpoint="lg"
             onMobileClose={() => {
                 const selected = applications.find((a) => a.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/portal/src/app/portal/candidates/components/split/split-view.tsx
+++ b/apps/portal/src/app/portal/candidates/components/split/split-view.tsx
@@ -42,7 +42,6 @@ export function SplitView({
             emptyIcon="fa-user"
             emptyTitle="Select a Candidate"
             emptyDescription="Click a candidate on the left to view their profile"
-            initialListWidth={33}
             onMobileClose={() => {
                 const selected = candidates.find((c) => c.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/portal/src/app/portal/companies/components/split/split-view.tsx
+++ b/apps/portal/src/app/portal/companies/components/split/split-view.tsx
@@ -48,7 +48,6 @@ export function SplitView({
             emptyIcon="fa-building"
             emptyTitle="Select a Company"
             emptyDescription="Click a company on the left to view their profile"
-            initialListWidth={33}
             onMobileClose={() => {
                 const selected = items.find((i) => {
                     const id = "company_id" in i ? i.company_id : i.id;

--- a/apps/portal/src/app/portal/company-invitations/components/split/split-view.tsx
+++ b/apps/portal/src/app/portal/company-invitations/components/split/split-view.tsx
@@ -39,7 +39,6 @@ export function SplitView({
             emptyIcon="fa-handshake"
             emptyTitle="Select a Connection"
             emptyDescription="Click a connection on the left to view details"
-            initialListWidth={33}
             onMobileClose={() => {
                 const selected = invitations.find((i) => i.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/portal/src/app/portal/firms/components/split/split-view.tsx
+++ b/apps/portal/src/app/portal/firms/components/split/split-view.tsx
@@ -38,7 +38,6 @@ export function SplitView({
             )}
             emptyIcon="fa-hand-pointer"
             emptyTitle="Select a firm to view details"
-            initialListWidth={25}
             onMobileClose={() => {
                 const selected = firms.find((f) => f.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/portal/src/app/portal/invitations/components/split/split-view.tsx
+++ b/apps/portal/src/app/portal/invitations/components/split/split-view.tsx
@@ -39,7 +39,6 @@ export function SplitView({
             emptyIcon="fa-hand-pointer"
             emptyTitle="Select an Invitation"
             emptyDescription="Click an invitation on the left to view details"
-            initialListWidth={40}
             onMobileClose={() => {
                 const selected = invitations.find((i) => i.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/portal/src/app/portal/invite-companies/components/split/split-view.tsx
+++ b/apps/portal/src/app/portal/invite-companies/components/split/split-view.tsx
@@ -39,7 +39,6 @@ export function SplitView({
             emptyIcon="fa-building-user"
             emptyTitle="Select an Invitation"
             emptyDescription="Click an invitation on the left to view details"
-            initialListWidth={40}
             onMobileClose={() => {
                 const selected = invitations.find((i) => i.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/portal/src/app/portal/matches/components/split/split-view.tsx
+++ b/apps/portal/src/app/portal/matches/components/split/split-view.tsx
@@ -44,7 +44,6 @@ export function SplitView({
             )}
             emptyIcon="fa-hand-pointer"
             emptyTitle="Select a match to view details"
-            initialListWidth={40}
             onMobileClose={() => {
                 const selected = matches.find((m) => m.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/portal/src/app/portal/placements/components/split/split-view.tsx
+++ b/apps/portal/src/app/portal/placements/components/split/split-view.tsx
@@ -38,7 +38,6 @@ export function SplitView({
             )}
             emptyIcon="fa-hand-pointer"
             emptyTitle="Select a placement to view details"
-            initialListWidth={40}
             onMobileClose={() => {
                 const selected = placements.find((p) => p.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/portal/src/app/portal/recruiters/components/grid/grid-card.tsx
+++ b/apps/portal/src/app/portal/recruiters/components/grid/grid-card.tsx
@@ -72,23 +72,6 @@ export function GridCard({
         >
             {/* Header Band */}
             <div className="relative bg-base-300 px-5 pt-4 pb-4">
-                {/* Kicker row: status + modifier badges */}
-                <div className="flex items-center gap-2 flex-wrap mb-3">
-                    <BaselBadge color={status === "active" ? "success" : status === "pending" ? "warning" : status === "suspended" ? "error" : "neutral"} variant="soft" size="sm">
-                        {formatStatus(status)}
-                    </BaselBadge>
-
-                    {recruiter.plan_tier && (
-                        <PlanBadge tier={recruiter.plan_tier as PlanTier} />
-                    )}
-
-                    {isNew(recruiter) && (
-                        <BaselBadge color="warning" variant="soft" size="sm" icon="fa-sparkles">
-                            New
-                        </BaselBadge>
-                    )}
-                </div>
-
                 {/* Editorial block: Avatar + Firm kicker → Name → Location */}
                 <div className="flex items-start gap-3">
                     <BaselAvatar
@@ -148,8 +131,22 @@ export function GridCard({
             </div>
 
             {/* Tags: partnership + specialties + industries */}
-            <div className="px-5 py-3 border-b border-base-300">
+            <div className="px-5 py-3">
                 <div className="flex flex-wrap gap-1.5">
+                    <BaselBadge color={status === "active" ? "success" : status === "pending" ? "warning" : status === "suspended" ? "error" : "neutral"} variant="soft" size="sm">
+                        {formatStatus(status)}
+                    </BaselBadge>
+
+                    {recruiter.plan_tier && (
+                        <PlanBadge tier={recruiter.plan_tier as PlanTier} />
+                    )}
+
+                    {isNew(recruiter) && (
+                        <BaselBadge color="warning" variant="soft" size="sm" icon="fa-sparkles">
+                            New
+                        </BaselBadge>
+                    )}
+
                     {recruiter.company_recruiter && (
                         <BaselBadge color="primary" size="sm" icon="fa-building">
                             Company
@@ -188,7 +185,7 @@ export function GridCard({
 
             {/* Footer: profile link + actions */}
             <div
-                className="mt-auto flex items-center justify-between gap-3 px-5 py-3"
+                className="mt-auto flex items-center justify-between gap-3 px-5 py-3 border-t border-base-300"
                 onClick={(e) => e.stopPropagation()}
             >
                 <Link

--- a/apps/portal/src/app/portal/recruiters/components/split/split-view.tsx
+++ b/apps/portal/src/app/portal/recruiters/components/split/split-view.tsx
@@ -39,7 +39,6 @@ export function SplitView({
             emptyIcon="fa-users"
             emptyTitle="Select a Recruiter"
             emptyDescription="Click a recruiter on the left to view their profile"
-            initialListWidth={33}
             onMobileClose={() => {
                 const selected = recruiters.find((r) => r.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/portal/src/app/portal/roles/components/split/split-view.tsx
+++ b/apps/portal/src/app/portal/roles/components/split/split-view.tsx
@@ -42,7 +42,6 @@ export function SplitView({
             )}
             emptyIcon="fa-hand-pointer"
             emptyTitle="Select a role to view details"
-            initialListWidth={33}
             onMobileClose={() => {
                 const selected = jobs.find((j) => j.id === selectedId);
                 if (selected) onSelect(selected);

--- a/apps/portal/src/components/basel/calendar/calendar-event-detail.tsx
+++ b/apps/portal/src/components/basel/calendar/calendar-event-detail.tsx
@@ -11,6 +11,7 @@ import {
     isInterviewEvent,
     parseInterviewSummary,
 } from "./calendar-context";
+import { sanitizeCalendarHtml } from "@splits-network/shared-ui";
 
 /* ─── Helpers ───────────────────────────────────────────────────────── */
 
@@ -256,7 +257,7 @@ export default function CalendarEventDetail() {
                         <div
                             className="text-sm text-base-content/70 whitespace-pre-wrap"
                             dangerouslySetInnerHTML={{
-                                __html: selectedEvent.description,
+                                __html: sanitizeCalendarHtml(selectedEvent.description),
                             }}
                         />
                     </div>

--- a/apps/portal/src/components/basel/email/email-message-card.tsx
+++ b/apps/portal/src/components/basel/email/email-message-card.tsx
@@ -3,10 +3,13 @@
 /**
  * Single email message card — expand/collapse body, sender info,
  * to/cc, reply action. Used within email-thread-detail.
+ *
+ * Email HTML is sanitized via DOMPurify to prevent XSS from external senders.
  */
 
 import { useState } from "react";
 import type { EmailMessage } from "@splits-network/shared-types";
+import { sanitizeEmailHtml } from "@splits-network/shared-ui";
 
 interface EmailMessageCardProps {
     message: EmailMessage;
@@ -113,7 +116,7 @@ export default function EmailMessageCard({
                             <div
                                 className="prose prose-sm max-w-none"
                                 dangerouslySetInnerHTML={{
-                                    __html: message.bodyHtml,
+                                    __html: sanitizeEmailHtml(message.bodyHtml),
                                 }}
                             />
                         ) : (

--- a/apps/portal/src/components/basel/email/email-thread-panel.tsx
+++ b/apps/portal/src/components/basel/email/email-thread-panel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useAuth } from "@clerk/nextjs";
 import { createAuthenticatedClient } from "@/lib/api-client";
+import { sanitizeEmailHtml } from "@splits-network/shared-ui";
 import type {
     OAuthConnectionPublic,
     EmailMessage,
@@ -416,9 +417,11 @@ export default function EmailThreadPanel({
                                         <div
                                             className="prose prose-sm max-w-none"
                                             dangerouslySetInnerHTML={{
-                                                __html: msg.bodyHtml.substring(
-                                                    0,
-                                                    3000,
+                                                __html: sanitizeEmailHtml(
+                                                    msg.bodyHtml.substring(
+                                                        0,
+                                                        3000,
+                                                    ),
                                                 ),
                                             }}
                                         />

--- a/packages/basel-ui/src/layout/basel-split-view.tsx
+++ b/packages/basel-ui/src/layout/basel-split-view.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-    useCallback,
-    useEffect,
-    useRef,
-    useState,
-    type ReactNode,
-} from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
@@ -37,23 +31,11 @@ export interface BaselSplitViewProps<T> {
     listHeader?: ReactNode;
     /** Optional footer pinned at bottom of list panel (pagination) */
     listFooter?: ReactNode;
-    /** Initial list panel width as percentage (default: 33) */
-    initialListWidth?: number;
-    /** Minimum list panel width as percentage (default: 20) */
-    minListWidth?: number;
-    /** Maximum list panel width as percentage (default: 50) */
-    maxListWidth?: number;
-    /** Responsive breakpoint for showing both panels (default: "md") */
-    mobileBreakpoint?: "md" | "lg";
     /** Additional class on the outer container */
     className?: string;
     /** Called when the user closes the mobile detail overlay */
     onMobileClose?: () => void;
 }
-
-/* ── Breakpoint pixel values ──────────────────────────────────── */
-
-const BP_PX = { md: 768, lg: 1024 } as const;
 
 /* ── Component ────────────────────────────────────────────────── */
 
@@ -70,67 +52,11 @@ export function BaselSplitView<T>({
     emptyDescription = "Click an item on the left to view details",
     listHeader,
     listFooter,
-    initialListWidth = 33,
-    minListWidth = 20,
-    maxListWidth = 50,
-    mobileBreakpoint = "md",
     className,
     onMobileClose,
 }: BaselSplitViewProps<T>) {
     const selectedItem =
         items.find((item) => getItemId(item) === selectedId) ?? null;
-
-    /* ── Resizable panel state ────────────────────────────────── */
-
-    const [listWidthPct, setListWidthPct] = useState(initialListWidth);
-    const containerRef = useRef<HTMLDivElement>(null);
-    const isDragging = useRef(false);
-
-    const handleDragStart = useCallback(
-        (e: React.MouseEvent | React.TouchEvent) => {
-            e.preventDefault();
-            isDragging.current = true;
-
-            const startX =
-                "touches" in e ? e.touches[0].clientX : e.clientX;
-            const container = containerRef.current;
-            if (!container) return;
-
-            const containerRect = container.getBoundingClientRect();
-            const containerWidth = containerRect.width;
-
-            const onMove = (ev: MouseEvent | TouchEvent) => {
-                const clientX =
-                    "touches" in ev
-                        ? ev.touches[0].clientX
-                        : (ev as MouseEvent).clientX;
-                const relX = clientX - containerRect.left;
-                const pct = Math.min(
-                    maxListWidth,
-                    Math.max(minListWidth, (relX / containerWidth) * 100),
-                );
-                setListWidthPct(pct);
-            };
-
-            const onUp = () => {
-                isDragging.current = false;
-                document.removeEventListener("mousemove", onMove);
-                document.removeEventListener("mouseup", onUp);
-                document.removeEventListener("touchmove", onMove);
-                document.removeEventListener("touchend", onUp);
-                document.body.style.cursor = "";
-                document.body.style.userSelect = "";
-            };
-
-            document.body.style.cursor = "col-resize";
-            document.body.style.userSelect = "none";
-            document.addEventListener("mousemove", onMove);
-            document.addEventListener("mouseup", onUp);
-            document.addEventListener("touchmove", onMove);
-            document.addEventListener("touchend", onUp);
-        },
-        [maxListWidth, minListWidth],
-    );
 
     /* ── Virtual scrolling ────────────────────────────────────── */
 
@@ -143,27 +69,17 @@ export function BaselSplitView<T>({
         overscan: 5,
     });
 
-    /* ── Mobile portal ────────────────────────────────────────── */
+    /* ── Mobile overlay ───────────────────────────────────────── */
 
     const [mounted, setMounted] = useState(false);
     useEffect(() => {
         setMounted(true);
     }, []);
 
-    const bp = mobileBreakpoint;
-    const bpHide = bp === "md" ? "hidden md:flex" : "hidden lg:flex";
-    const bpShow = bp === "md" ? "md:hidden" : "lg:hidden";
-    const bpBlock = bp === "md" ? "hidden md:block" : "hidden lg:block";
-    const bpListHide =
-        bp === "md" ? "hidden md:flex" : "hidden lg:flex";
-
     const mobileOverlay =
         selectedItem && mounted
             ? createPortal(
-                  <div
-                      className={`fixed inset-0 z-50 flex flex-col bg-base-100 ${bpShow}`}
-                  >
-                      {/* Back button */}
+                  <div className="fixed inset-0 z-50 flex flex-col bg-base-100 md:hidden">
                       <div className="border-b-2 border-base-300 px-4 py-2 flex items-center">
                           <button
                               onClick={onMobileClose}
@@ -211,28 +127,17 @@ export function BaselSplitView<T>({
             {mobileOverlay}
 
             <div
-                ref={containerRef}
                 className={`flex h-full min-h-0 overflow-hidden border-2 border-base-300 ${className ?? ""}`}
             >
-                {/* ── List panel ──────────────────────────────── */}
-                <div
-                    className={`flex flex-col overflow-hidden ${
-                        selectedId ? bpListHide : "flex"
-                    }`}
-                    style={{ width: `${listWidthPct}%`, flexShrink: 0 }}
-                >
-                    {/* Optional list header */}
+                {/* ── List panel: full-width mobile, 1/3 desktop ── */}
+                <div className="flex w-full md:w-1/3 flex-col overflow-hidden flex-shrink-0 md:border-r-2 md:border-base-300">
                     {listHeader && (
                         <div className="border-b border-base-300 flex-shrink-0">
                             {listHeader}
                         </div>
                     )}
 
-                    {/* Virtualized list */}
-                    <div
-                        ref={listScrollRef}
-                        className="flex-1 overflow-y-auto"
-                    >
+                    <div ref={listScrollRef} className="flex-1 overflow-y-auto">
                         <div
                             style={{
                                 height: virtualizer.getTotalSize(),
@@ -256,17 +161,13 @@ export function BaselSplitView<T>({
                                             transform: `translateY(${vRow.start}px)`,
                                         }}
                                     >
-                                        {renderItem(
-                                            item,
-                                            selectedId === id,
-                                        )}
+                                        {renderItem(item, selectedId === id)}
                                     </div>
                                 );
                             })}
                         </div>
                     </div>
 
-                    {/* Optional list footer (pagination) */}
                     {listFooter && (
                         <div className="border-t border-base-300 flex-shrink-0">
                             {listFooter}
@@ -274,47 +175,10 @@ export function BaselSplitView<T>({
                     )}
                 </div>
 
-                {/* ── Resize handle ───────────────────────────── */}
-                <div
-                    className={`${bpBlock} w-[5px] flex-shrink-0 bg-base-300 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors relative group`}
-                    onMouseDown={handleDragStart}
-                    onTouchStart={handleDragStart}
-                    role="separator"
-                    aria-orientation="vertical"
-                    aria-valuenow={Math.round(listWidthPct)}
-                    aria-valuemin={minListWidth}
-                    aria-valuemax={maxListWidth}
-                    tabIndex={0}
-                    onKeyDown={(e) => {
-                        if (e.key === "ArrowLeft") {
-                            setListWidthPct((w) =>
-                                Math.max(minListWidth, w - 1),
-                            );
-                        } else if (e.key === "ArrowRight") {
-                            setListWidthPct((w) =>
-                                Math.min(maxListWidth, w + 1),
-                            );
-                        }
-                    }}
-                >
-                    {/* Visual grip dots */}
-                    <div className="absolute inset-y-0 left-0 right-0 flex items-center justify-center pointer-events-none">
-                        <div className="flex flex-col gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                            <div className="w-1 h-1 bg-base-content/30" />
-                            <div className="w-1 h-1 bg-base-content/30" />
-                            <div className="w-1 h-1 bg-base-content/30" />
-                        </div>
-                    </div>
-                </div>
-
-                {/* ── Detail panel ────────────────────────────── */}
-                <div
-                    className={`${bpHide} flex-col flex-1 min-w-0 overflow-hidden`}
-                >
+                {/* ── Detail panel: hidden mobile, 2/3 desktop ── */}
+                <div className="hidden md:flex flex-col flex-1 min-w-0 overflow-hidden">
                     <div className="flex-1 overflow-y-auto bg-base-100">
-                        {selectedItem
-                            ? renderDetail(selectedItem)
-                            : emptyState}
+                        {selectedItem ? renderDetail(selectedItem) : emptyState}
                     </div>
                 </div>
             </div>

--- a/packages/basel-ui/src/navigation/sidebar.tsx
+++ b/packages/basel-ui/src/navigation/sidebar.tsx
@@ -303,13 +303,13 @@ export function BaselSidebar({
     const sidebarContent = (
         <aside
             ref={containerRef as React.RefObject<HTMLElement>}
-            className={`${width} h-full bg-base-300 text-base-content flex flex-col border-t-4 border-r-4 border-primary ${className || ""}`}
+            className={`${width} h-full bg-base-300 text-base-content flex flex-col border-t-2 border-r-2 border-primary ${className || ""}`}
         >
             {/* Brand slot */}
             {brand && <div className="sidebar-brand p-5 pb-3">{brand}</div>}
 
             {/* Navigation */}
-            <nav className="flex-1 px-3 py-2 overflow-y-auto border-r-4 border-primary">
+            <nav className="flex-1 px-3 py-2 overflow-y-auto">
                 {sections.map((section, sIdx) => (
                     <div key={section.title || `section-${sIdx}`}>
                         {section.title && (

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "@uiw/react-markdown-preview": "^5.1.5",
         "@uiw/react-md-editor": "^4.0.0",
+        "isomorphic-dompurify": "^3.5.1",
         "react-markdown": "^9.0.0",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.0",
@@ -24,6 +25,7 @@
         "react-dom": "^19.0.0"
     },
     "devDependencies": {
+        "@types/dompurify": "^3.2.0",
         "@types/react": "^19.0.1",
         "@types/react-dom": "^19.0.2",
         "typescript": "^5.9.3"

--- a/packages/shared-ui/src/html-sanitizer/index.ts
+++ b/packages/shared-ui/src/html-sanitizer/index.ts
@@ -1,0 +1,1 @@
+export { sanitizeEmailHtml, sanitizeCalendarHtml } from './sanitize-html';

--- a/packages/shared-ui/src/html-sanitizer/sanitize-html.ts
+++ b/packages/shared-ui/src/html-sanitizer/sanitize-html.ts
@@ -1,0 +1,42 @@
+import DOMPurify from 'isomorphic-dompurify';
+
+const EMAIL_CONFIG = {
+    ALLOWED_TAGS: [
+        'div', 'span', 'p', 'br', 'hr',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'b', 'i', 'u', 'em', 'strong', 'small', 'sub', 'sup', 'mark',
+        'ul', 'ol', 'li',
+        'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'caption', 'colgroup', 'col',
+        'a', 'img',
+        'blockquote', 'pre', 'code',
+        'center', 'font',
+    ],
+    ALLOWED_ATTR: [
+        'href', 'target', 'rel',
+        'src', 'alt', 'width', 'height',
+        'colspan', 'rowspan', 'cellpadding', 'cellspacing', 'border',
+        'align', 'valign',
+        'style', 'class',
+        'color', 'size', 'face',
+    ],
+    ALLOW_DATA_ATTR: false,
+    FORBID_TAGS: ['script', 'iframe', 'object', 'embed', 'form', 'input', 'textarea', 'select', 'button'],
+    FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur'],
+};
+
+const CALENDAR_CONFIG = {
+    ALLOWED_TAGS: [
+        'p', 'br', 'b', 'i', 'em', 'strong', 'u',
+        'a', 'ul', 'ol', 'li', 'div', 'span',
+    ],
+    ALLOWED_ATTR: ['href', 'target', 'rel'],
+    ALLOW_DATA_ATTR: false,
+};
+
+export function sanitizeEmailHtml(html: string): string {
+    return DOMPurify.sanitize(html, EMAIL_CONFIG);
+}
+
+export function sanitizeCalendarHtml(html: string): string {
+    return DOMPurify.sanitize(html, CALENDAR_CONFIG);
+}

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -1,6 +1,7 @@
 export { MarkdownEditor, type MarkdownEditorProps, markdownToolbarCommands } from './markdown/markdown-editor';
 export { MarkdownRenderer, type MarkdownRendererProps, markdownRenderConfig } from './markdown/markdown-renderer';
 export { JsonLd } from './seo/json-ld';
+export { sanitizeEmailHtml, sanitizeCalendarHtml } from './html-sanitizer';
 
 // Browse components
 export { BrowseLayout } from './browse/browse-layout';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   apps/corporate:
     dependencies:
@@ -764,6 +764,9 @@ importers:
       '@uiw/react-md-editor':
         specifier: ^4.0.0
         version: 4.0.11(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      isomorphic-dompurify:
+        specifier: ^3.5.1
+        version: 3.5.1
       next:
         specifier: ^16.0.0
         version: 16.1.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -786,6 +789,9 @@ importers:
         specifier: ^11.0.5
         version: 11.0.5
     devDependencies:
+      '@types/dompurify':
+        specifier: ^3.2.0
+        version: 3.2.0
       '@types/react':
         specifier: ^19.0.1
         version: 19.2.7
@@ -954,7 +960,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -963,7 +969,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/analytics-gateway:
     dependencies:
@@ -997,7 +1003,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/analytics-service:
     dependencies:
@@ -1067,7 +1073,7 @@ importers:
         version: 3.0.11
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@22.19.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1076,7 +1082,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@22.19.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/api-gateway:
     dependencies:
@@ -1143,7 +1149,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1152,7 +1158,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/ats-service:
     dependencies:
@@ -1201,7 +1207,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1210,7 +1216,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/automation-service:
     dependencies:
@@ -1262,7 +1268,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1271,7 +1277,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/billing-service:
     dependencies:
@@ -1323,7 +1329,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1332,7 +1338,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/call-service:
     dependencies:
@@ -1387,7 +1393,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1396,7 +1402,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/chat-gateway:
     dependencies:
@@ -1424,7 +1430,7 @@ importers:
         version: 8.18.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1433,7 +1439,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/chat-service:
     dependencies:
@@ -1485,7 +1491,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1494,7 +1500,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/content-service:
     dependencies:
@@ -1543,7 +1549,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1552,7 +1558,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/document-processing-service:
     dependencies:
@@ -1613,7 +1619,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.4
-        version: 1.6.1(@types/node@20.19.27)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 1.6.1(@types/node@20.19.27)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/document-service:
     dependencies:
@@ -1717,7 +1723,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1726,7 +1732,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/gpt-service:
     dependencies:
@@ -1790,7 +1796,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/health-monitor:
     dependencies:
@@ -1827,7 +1833,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1836,7 +1842,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/identity-service:
     dependencies:
@@ -1897,7 +1903,7 @@ importers:
         version: 10.0.0
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1906,7 +1912,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/integration-service:
     dependencies:
@@ -1946,6 +1952,9 @@ importers:
       fastify:
         specifier: ^5.6.2
         version: 5.6.2
+      sanitize-html:
+        specifier: ^2.17.1
+        version: 2.17.1
     devDependencies:
       '@types/amqplib':
         specifier: ^0.10.5
@@ -1953,9 +1962,12 @@ importers:
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1964,7 +1976,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/matching-service:
     dependencies:
@@ -2013,7 +2025,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -2022,7 +2034,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/network-service:
     dependencies:
@@ -2071,7 +2083,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -2080,7 +2092,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/notification-service:
     dependencies:
@@ -2129,7 +2141,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -2138,7 +2150,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/onboarding-service:
     dependencies:
@@ -2181,7 +2193,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -2190,7 +2202,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/search-service:
     dependencies:
@@ -2230,7 +2242,7 @@ importers:
         version: 22.19.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@22.19.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -2239,7 +2251,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@22.19.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/support-gateway:
     dependencies:
@@ -2322,7 +2334,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -2331,7 +2343,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
   services/video-service:
     dependencies:
@@ -2386,7 +2398,7 @@ importers:
         version: 24.10.1
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -2395,7 +2407,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
 
 packages:
 
@@ -2412,6 +2424,17 @@ packages:
 
   '@apm-js-collab/tracing-hooks@0.3.1':
     resolution: {integrity: sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw==}
+
+  '@asamuzakjp/css-color@5.0.1':
+    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.3':
+    resolution: {integrity: sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -2494,6 +2517,10 @@ packages:
   '@borewit/text-codec@0.1.1':
     resolution: {integrity: sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@bufbuild/protobuf@1.10.1':
     resolution: {integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==}
 
@@ -2551,6 +2578,42 @@ packages:
   '@clerk/types@4.101.9':
     resolution: {integrity: sha512-RO00JqqmkIoI1o0XCtvudjaLpqEoe8PRDHlLS1r/aNZazUQCO0TT6nZOx1F3X+QJDjqYVY7YmYl3mtO2QVEk1g==}
     engines: {node: '>=18.17.0'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1':
+    resolution: {integrity: sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -2873,6 +2936,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@fastify/accept-negotiator@2.0.1':
     resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
@@ -3935,6 +4007,10 @@ packages:
   '@types/dom-mediacapture-record@1.0.22':
     resolution: {integrity: sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==}
 
+  '@types/dompurify@3.2.0':
+    resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
+    deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -4015,8 +4091,14 @@ packages:
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -4349,6 +4431,9 @@ packages:
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -4575,6 +4660,10 @@ packages:
   css-selector-parser@3.3.0:
     resolution: {integrity: sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
@@ -4586,6 +4675,10 @@ packages:
 
   daisyui@5.5.8:
     resolution: {integrity: sha512-6psL9jIEOFOw68V10j/BKCWcRgx8dh81mmNxShr+g7HDM6UHNoPharlp9zq/PQkHNuGU1ZQsajR3HgpvavbRKQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -4601,6 +4694,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -4660,6 +4756,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4721,6 +4820,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -4768,6 +4871,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -5125,6 +5232,10 @@ packages:
     resolution: {integrity: sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -5137,6 +5248,9 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -5239,6 +5353,13 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -5254,6 +5375,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-dompurify@3.5.1:
+    resolution: {integrity: sha512-LlUCZikq/W6CmSq1UWcFLgS4nhkNBwimmVyNQtdByDffT0yVjKYef9lincZ7/ohBlknPkX1C97BBmjeNuFFR4Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -5316,6 +5441,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.0.0:
+    resolution: {integrity: sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5538,6 +5672,10 @@ packages:
     resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -5622,6 +5760,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -5936,8 +6077,14 @@ packages:
   parse-numeric-range@1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -6142,6 +6289,10 @@ packages:
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
@@ -6385,6 +6536,13 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.1:
+    resolution: {integrity: sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -6631,6 +6789,9 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.1.17:
     resolution: {integrity: sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==}
 
@@ -6714,6 +6875,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.26:
+    resolution: {integrity: sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==}
+
+  tldts@7.0.26:
+    resolution: {integrity: sha512-WiGwQjr0qYdNNG8KpMKlSvpxz652lqa3Rd+/hSaDcY4Uo6SKWZq2LAF+hsAhUewTtYhXlorBKgNF3Kk8hnjGoQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -6730,8 +6898,16 @@ packages:
     resolution: {integrity: sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==}
     engines: {node: '>=14.16'}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -6824,6 +7000,10 @@ packages:
 
   undici@7.16.0:
     resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.24.4:
+    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -7042,6 +7222,10 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -7055,6 +7239,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
@@ -7076,6 +7264,14 @@ packages:
   webrtc-adapter@9.0.4:
     resolution: {integrity: sha512-5ZZY1+lGq8LEKuDlg9M2RPJHlH3R7OVwyHqMcUsLKCgd9Wvf+QrFTCItkXXYPmrJn8H6gRLXbSgxLLdexiqHxw==}
     engines: {node: '>=6.0.0', npm: '>=3.10.0'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -7113,9 +7309,16 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xmlbuilder@10.1.1:
     resolution: {integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==}
     engines: {node: '>=4.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -7169,6 +7372,24 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
+
+  '@asamuzakjp/css-color@5.0.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/dom-selector@7.0.3':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -7278,6 +7499,10 @@ snapshots:
 
   '@borewit/text-codec@0.1.1': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@bufbuild/protobuf@1.10.1': {}
 
   '@clerk/backend@2.25.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
@@ -7358,6 +7583,30 @@ snapshots:
     transitivePeerDependencies:
       - react
       - react-dom
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.1)':
     dependencies:
@@ -7537,6 +7786,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.1':
     optional: true
+
+  '@exodus/bytes@1.15.0': {}
 
   '@fastify/accept-negotiator@2.0.1': {}
 
@@ -8714,6 +8965,10 @@ snapshots:
 
   '@types/dom-mediacapture-record@1.0.22': {}
 
+  '@types/dompurify@3.2.0':
+    dependencies:
+      dompurify: 3.3.3
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -8808,9 +9063,16 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 22.19.1
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -8859,7 +9121,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.1)(lightningcss@1.30.2)(terser@5.44.1))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -8873,11 +9135,11 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.19.1)(lightningcss@1.30.2)(terser@5.44.1)
+      vitest: 2.1.9(@types/node@22.19.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -8891,11 +9153,11 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+      vitest: 2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -8910,7 +9172,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9249,6 +9511,10 @@ snapshots:
 
   bcp-47-match@2.0.3: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   binary-extensions@2.3.0: {}
 
   bintrees@1.0.2: {}
@@ -9455,6 +9721,11 @@ snapshots:
 
   css-selector-parser@3.3.0: {}
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.1.3: {}
 
   csstype@3.2.3: {}
@@ -9463,6 +9734,13 @@ snapshots:
 
   daisyui@5.5.8: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   date-fns@4.1.0: {}
 
   dateformat@4.6.3: {}
@@ -9470,6 +9748,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -9481,8 +9761,7 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
-  deepmerge@4.3.1:
-    optional: true
+  deepmerge@4.3.1: {}
 
   delayed-stream@1.0.0: {}
 
@@ -9509,22 +9788,22 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       entities: 4.5.0
-    optional: true
 
-  domelementtype@2.3.0:
-    optional: true
+  domelementtype@2.3.0: {}
 
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
-    optional: true
+
+  dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-    optional: true
 
   dotenv@16.6.1: {}
 
@@ -9575,10 +9854,11 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
-  entities@4.5.0:
-    optional: true
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -9673,6 +9953,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
@@ -10223,6 +10505,12 @@ snapshots:
 
   hono@4.12.2: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   html-to-text@9.0.5:
@@ -10238,13 +10526,19 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   htmlparser2@8.0.2:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 4.5.0
-    optional: true
 
   http-errors@2.0.1:
     dependencies:
@@ -10341,6 +10635,10 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-plain-object@5.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-reference@1.2.1:
@@ -10352,6 +10650,14 @@ snapshots:
   isarray@1.0.0: {}
 
   isexe@2.0.0: {}
+
+  isomorphic-dompurify@3.5.1:
+    dependencies:
+      dompurify: 3.3.3
+      jsdom: 29.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - canvas
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -10420,6 +10726,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.0.0:
+    dependencies:
+      '@asamuzakjp/css-color': 5.0.1
+      '@asamuzakjp/dom-selector': 7.0.3
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.4
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -10632,6 +10964,8 @@ snapshots:
 
   lru-cache@11.2.4: {}
 
+  lru-cache@11.2.7: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -10837,6 +11171,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -11293,7 +11629,13 @@ snapshots:
 
   parse-numeric-range@1.3.0: {}
 
+  parse-srcset@1.0.2: {}
+
   parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  parse5@8.0.0:
     dependencies:
       entities: 6.0.1
 
@@ -11502,6 +11844,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode@2.3.1: {}
 
   qs@6.14.0:
     dependencies:
@@ -11874,6 +12218,19 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sanitize-html@2.17.1:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 8.0.2
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.6
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   schema-utils@4.3.3:
@@ -12164,6 +12521,8 @@ snapshots:
       react: 19.2.1
       use-sync-external-store: 1.6.0(react@19.2.1)
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.1.17: {}
 
   tapable@2.3.0: {}
@@ -12229,6 +12588,12 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.26: {}
+
+  tldts@7.0.26:
+    dependencies:
+      tldts-core: 7.0.26
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -12243,7 +12608,15 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.26
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -12325,6 +12698,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici@7.16.0: {}
+
+  undici@7.24.4: {}
 
   unified@11.0.5:
     dependencies:
@@ -12547,7 +12922,7 @@ snapshots:
       lightningcss: 1.30.2
       terser: 5.44.1
 
-  vitest@1.6.1(@types/node@20.19.27)(lightningcss@1.30.2)(terser@5.44.1):
+  vitest@1.6.1(@types/node@20.19.27)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -12571,6 +12946,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.27
+      jsdom: 29.0.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -12581,7 +12957,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@22.19.1)(lightningcss@1.30.2)(terser@5.44.1):
+  vitest@2.1.9(@types/node@22.19.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.1)(lightningcss@1.30.2)(terser@5.44.1))
@@ -12605,6 +12981,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.1
+      jsdom: 29.0.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -12616,7 +12993,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1):
+  vitest@2.1.9(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1))
@@ -12640,6 +13017,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.1
+      jsdom: 29.0.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -12651,7 +13029,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jsdom@29.0.0)(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -12679,6 +13057,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.10.1
+      jsdom: 29.0.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -12690,6 +13069,10 @@ snapshots:
       - supports-color
       - terser
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -12700,6 +13083,8 @@ snapshots:
   web-streams-polyfill@4.0.0-beta.3: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
 
   webpack-sources@3.3.3: {}
 
@@ -12741,6 +13126,16 @@ snapshots:
     dependencies:
       sdp: 3.2.1
 
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -12771,7 +13166,11 @@ snapshots:
 
   ws@8.18.3: {}
 
+  xml-name-validator@5.0.0: {}
+
   xmlbuilder@10.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/services/integration-service/package.json
+++ b/services/integration-service/package.json
@@ -23,11 +23,13 @@
         "@splits-network/shared-types": "workspace:*",
         "@supabase/supabase-js": "^2.86.2",
         "amqplib": "^0.10.9",
-        "fastify": "^5.6.2"
+        "fastify": "^5.6.2",
+        "sanitize-html": "^2.17.1"
     },
     "devDependencies": {
         "@types/amqplib": "^0.10.5",
         "@types/node": "^24.10.1",
+        "@types/sanitize-html": "^2.16.1",
         "@vitest/coverage-v8": "^3.0.0",
         "tsx": "^4.19.2",
         "typescript": "^5.9.3",

--- a/services/integration-service/src/v2/email/sanitize.ts
+++ b/services/integration-service/src/v2/email/sanitize.ts
@@ -1,0 +1,27 @@
+import sanitize from 'sanitize-html';
+
+const EMAIL_OPTIONS: sanitize.IOptions = {
+    allowedTags: [
+        ...sanitize.defaults.allowedTags,
+        'img', 'h1', 'h2',
+        'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th',
+        'caption', 'colgroup', 'col',
+        'center', 'font', 'hr',
+    ],
+    allowedAttributes: {
+        ...sanitize.defaults.allowedAttributes,
+        '*': ['style', 'class', 'align', 'valign'],
+        img: ['src', 'alt', 'width', 'height'],
+        a: ['href', 'target', 'rel'],
+        td: ['colspan', 'rowspan', 'width', 'height'],
+        th: ['colspan', 'rowspan'],
+        table: ['cellpadding', 'cellspacing', 'border', 'width'],
+        font: ['color', 'size', 'face'],
+    },
+    allowedSchemes: ['http', 'https', 'mailto'],
+};
+
+export function sanitizeEmailBody(html: string | undefined): string | undefined {
+    if (!html) return html;
+    return sanitize(html, EMAIL_OPTIONS);
+}

--- a/services/integration-service/src/v2/email/service.ts
+++ b/services/integration-service/src/v2/email/service.ts
@@ -3,6 +3,7 @@ import { ConnectionRepository } from '../connections/repository';
 import { TokenRefreshService } from '../calendar/token-refresh';
 import { GmailClient, GmailMessage } from './gmail-client';
 import { MicrosoftMailClient, MicrosoftMailMessage } from './microsoft-mail-client';
+import { sanitizeEmailBody } from './sanitize';
 import type { EmailMessage, EmailThread, EmailListResponse, EmailListItem } from '@splits-network/shared-types';
 
 /* ── Unified send params ─────────────────────────────────────────────── */
@@ -268,7 +269,7 @@ export class EmailService {
             isRead: !(msg.labelIds?.includes('UNREAD') ?? false),
             hasAttachments: msg.payload.parts?.some(p => p.mimeType?.startsWith('application/') || p.mimeType?.startsWith('image/')) ?? false,
             bodyText,
-            bodyHtml,
+            bodyHtml: sanitizeEmailBody(bodyHtml),
         };
     }
 
@@ -285,7 +286,7 @@ export class EmailService {
             isRead: msg.isRead,
             hasAttachments: msg.hasAttachments,
             bodyText: msg.body.contentType === 'Text' ? msg.body.content : undefined,
-            bodyHtml: msg.body.contentType === 'HTML' ? msg.body.content : undefined,
+            bodyHtml: msg.body.contentType === 'HTML' ? sanitizeEmailBody(msg.body.content) : undefined,
             webLink: msg.webLink,
         };
     }


### PR DESCRIPTION
- Added `sanitize-html` package to handle email body sanitization.
- Implemented `sanitizeEmailBody` function in the email service to sanitize email content.
- Created a new HTML sanitizer module in shared UI with configurations for email and calendar HTML.
- Updated email service to use the new sanitization functions for both HTML body and email messages.