### PR TITLE
Add view mode options to ControlsBar component

### DIFF
--- a/apps/candidate/src/app/(public)/jobs/components/shared/controls-bar.tsx
+++ b/apps/candidate/src/app/(public)/jobs/components/shared/controls-bar.tsx
@@ -76,6 +76,11 @@ export function ControlsBar({
                     <BaselViewModeSelector
                         viewMode={viewMode}
                         onViewModeChange={onViewModeChange}
+                        modes={[
+                            { mode: "table", icon: "fa-table-list", label: "Table" },
+                            { mode: "grid", icon: "fa-grid-2", label: "Grid" },
+                            { mode: "split", icon: "fa-columns-3", label: "Split" },
+                        ]}
                     />
                 </>
             }

--- a/apps/portal/src/app/portal/roles/components/shared/controls-bar.tsx
+++ b/apps/portal/src/app/portal/roles/components/shared/controls-bar.tsx
@@ -151,6 +151,11 @@ export function ControlsBar({
                     <BaselViewModeSelector
                         viewMode={viewMode}
                         onViewModeChange={onViewModeChange}
+                        modes={[
+                            { mode: "table", icon: "fa-table-list", label: "Table" },
+                            { mode: "grid", icon: "fa-grid-2", label: "Grid" },
+                            { mode: "split", icon: "fa-columns-3", label: "Split" },
+                        ]}
                     />
                     <BaselExpandToggle
                         expanded={expanded || hasExpandedFilters}


### PR DESCRIPTION
Enhance the ControlsBar component by introducing additional view mode options, allowing users to switch between table, grid, and split views.